### PR TITLE
fixed some issues and removed option

### DIFF
--- a/Adafruit_Video_Looper/video_looper.py
+++ b/Adafruit_Video_Looper/video_looper.py
@@ -141,6 +141,9 @@ class VideoLooper:
                         raise RuntimeError('Playlist path {0} does not exist.'.format(playlist_path))
                 else:
                     paths = self._reader.search_paths()
+                    if not paths:
+                        return Playlist([])
+                    
                     for path in paths:
                         maybe_playlist_path = os.path.join(path, playlist_path)
                         if os.path.isfile(maybe_playlist_path):

--- a/Adafruit_Video_Looper/video_looper.py
+++ b/Adafruit_Video_Looper/video_looper.py
@@ -122,7 +122,7 @@ class VideoLooper:
                 image = pygame.transform.scale(image, self._size)
         return image
 
-    def _is_number(iself, s):
+    def _is_number(self, s):
         try:
             float(s) 
             return True
@@ -150,22 +150,11 @@ class VideoLooper:
                     else:
                         raise RuntimeError('Playlist path {0} does not resolve to any file.'.format(playlist_path))
 
-                if self._config.has_option('playlist', 'format'):
-                    playlist_format = self._config.get('playlist', 'format').lower()
-                else:
-                    playlist_format = "auto"
-
-                if playlist_format == "auto":
-                    basepath, extension = os.path.splitext(playlist_path)
-                    if extension == '.m3u' or extension == '.m3u8':
-                        playlist_format = "m3u"
-                    else:
-                        raise RuntimeError('Unrecognized playlist extension {0}.'.format(extension))
-
-                if playlist_format == "m3u":
+                basepath, extension = os.path.splitext(playlist_path)
+                if extension == '.m3u' or extension == '.m3u8':
                     return build_playlist_m3u(playlist_path)
                 else:
-                    raise RuntimeError('Unrecognized playlist format {0}.'.format(playlist_format))
+                    raise RuntimeError('Unrecognized playlist format {0}.'.format(extension))
             else:
                 return self._build_playlist_from_all_files()
         else:

--- a/assets/video_looper.ini
+++ b/assets/video_looper.ini
@@ -127,12 +127,6 @@ password = videopi
 path = 
 #path = playlist.m3u
 
-# Playlist format.
-# Auto is based on the extension.
-format = auto
-#format = m3u
-
-
 # omxplayer configuration follows.
 [omxplayer]
 

--- a/reload.sh
+++ b/reload.sh
@@ -2,7 +2,7 @@
 
 # Make sure script is run as root.
 if [ "$(id -u)" != "0" ]; then
-  echo "Must be run as root with sudo! Try: sudo ./enable.sh"
+  echo "Must be run as root with sudo! Try: sudo ./reload.sh"
   exit 1
 fi
 


### PR DESCRIPTION
if player is in usb_mode and an playlist path is set and no usb drive is connected the player will just exit with a runtime error since playlist path does not exist...
as long as there are no paths an empty playlist will be returned to the main function as to not break the player and waiting for a usb connection